### PR TITLE
hover state will now clear on ios/android when clicking keys

### DIFF
--- a/src/cc/cote/feathers/softkeyboard/Key.as
+++ b/src/cc/cote/feathers/softkeyboard/Key.as
@@ -458,7 +458,7 @@ package cc.cote.feathers.softkeyboard
 				if ( !hitTest(touchPosInOriginalKeySpace, true) ) return;
 				
 				// Trigger event
-				changeState(HOVER_STATE);
+				changeState(UP_STATE);
 				_triggerEvent(this, KeyEvent.KEY_UP);
 				
 			}


### PR DESCRIPTION
I found that my hover button skin was not clearing on iOS/Android.  Patched the code to flip to "UP" on touch out.
